### PR TITLE
perf(cursor-glow): 移除 blur filter 降低 GPU 占用

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,17 +172,17 @@
         },
         "woodfishTheme.cursor.glowBlur": {
           "type": "number",
-          "default": 4,
+          "default": 0,
           "minimum": 0,
           "maximum": 24,
-          "markdownDescription": "效果：调节光标尾迹的柔和程度。单位：像素 `px`，范围 `0 - 24`。原理：运行时会替换尾迹样式中的 `blur(...)` 半径。例子：`2` 更清晰，`4` 默认，`8` 更梦幻。为什么要有这个项：相同颜色在不同 DPI 和显示器上，模糊半径的体感差异很大。"
+          "markdownDescription": "效果：按需开启光标尾迹模糊。单位：像素 `px`，范围 `0 - 24`，默认 `0` 表示不启用 GPU blur。原理：只有值大于 `0` 时，运行时才会添加 `blur(...)`。例子：保持 `0` 获得更低的 GPU 开销，设为 `4` 可恢复柔和光晕。为什么要有这个项：默认优先性能，同时保留用户主动选择模糊效果的能力。"
         },
         "woodfishTheme.cursor.glowOpacity": {
           "type": "number",
           "default": 0.7,
           "minimum": 0,
           "maximum": 1,
-          "markdownDescription": "效果：调节光标尾迹发光的存在感。单位：透明度，范围 `0 - 1`。原理：运行时会替换尾迹的 RGBA alpha 值。例子：`0.35` 更克制，`0.7` 默认，`1` 最亮。为什么要有这个项：这样用户可以控制“看得见多少”，而不是只能全开或全关。"
+          "markdownDescription": "效果：调节光标尾迹发光的存在感。单位：透明度，范围 `0 - 1`。原理：运行时会替换尾迹层的 `opacity`。例子：`0.35` 更克制，`0.7` 默认，`1` 最亮。为什么要有这个项：这样用户可以控制“看得见多少”，而不是只能全开或全关。"
         },
         "woodfishTheme.cursor.customRules": {
           "type": "array",

--- a/src/__tests__/payloadBuilder.test.ts
+++ b/src/__tests__/payloadBuilder.test.ts
@@ -130,6 +130,43 @@ describe('runtime payload builder', () => {
     expect(css.match(/div\.cursor::after\s*\{/g)).toHaveLength(1);
   });
 
+  it('keeps cursor glow filter-free by default and applies configured opacity', () => {
+    const css = buildRuntimeCss(
+      normalizeRuntimeSettings({
+        cursor: {
+          enabled: true,
+          glow: true,
+          glowOpacity: 0.45,
+        },
+      }),
+      realCursorAssets
+    );
+    const glowLayer = css.match(/div\.cursor::after\s*\{[\s\S]*?\}/)?.[0];
+
+    expect(glowLayer).toContain('filter: none !important;');
+    expect(glowLayer).toContain('opacity: 0.45 !important;');
+    expect(glowLayer).toContain(
+      'linear-gradient(180deg, #ff2d95, #ff4500, #ffd700, #7cfc00, #00ffff, #1e90ff, #9370db, #ff00ff, #ff1493)'
+    );
+    expect(glowLayer).not.toContain('brightness(');
+  });
+
+  it('allows cursor blur as an explicit opt-in', () => {
+    const css = buildRuntimeCss(
+      normalizeRuntimeSettings({
+        cursor: {
+          enabled: true,
+          glow: true,
+          glowBlur: 6,
+        },
+      }),
+      realCursorAssets
+    );
+    const glowLayer = css.match(/div\.cursor::after\s*\{[\s\S]*?\}/)?.[0];
+
+    expect(glowLayer).toContain('filter: blur(6px) !important;');
+  });
+
   it('uses transform-driven cursor flow in the runtime payload', () => {
     const css = buildRuntimeCss(
       normalizeRuntimeSettings({

--- a/src/services/runtime/payloadBuilder.ts
+++ b/src/services/runtime/payloadBuilder.ts
@@ -103,8 +103,14 @@ function buildCursorCss(settings: CursorSettings, assets: RuntimeCssAssets): str
 
   if (settings.glow) {
     const glowStrength = Math.max(0, Math.min(1, settings.glowOpacity));
+    const glowBlur = Math.max(0, settings.glowBlur);
+    const glowFilter = glowBlur > 0 ? `blur(${glowBlur}px)` : 'none';
     const glowLayer = applyCursorSettings(assets.cursorGlow, settings)
-      .replace(/blur\(4px\)/gi, `blur(${settings.glowBlur}px)`)
+      .replace(/filter:\s*none\s*!important;/gi, `filter: ${glowFilter} !important;`)
+      .replace(
+        /opacity:\s*(?:0(?:\.\d+)?|1(?:\.0+)?)\s*!important;/gi,
+        `opacity: ${glowStrength} !important;`
+      )
       .replace(/rgba\(255,\s*255,\s*255,\s*0\.7\)/gi, `rgba(255, 255, 255, ${glowStrength})`);
     parts.push(glowLayer);
 

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -67,7 +67,7 @@ export const DEFAULT_RUNTIME_SETTINGS: ThemeRuntimeSettings = {
     ],
     borderRadius: 2,
     glow: true,
-    glowBlur: 4,
+    glowBlur: 0,
     glowOpacity: 0.7,
     customRules: [],
   },

--- a/themes/Bearded Theme/cursor-glow.css
+++ b/themes/Bearded Theme/cursor-glow.css
@@ -1,4 +1,4 @@
-/* Cursor glow layer — static low-opacity gradient replaces blur filter for performance */
+/* Cursor glow is filter-free by default; runtime settings can opt back into blur. */
 div.cursor::after {
   content: '' !important;
   position: absolute !important;
@@ -8,19 +8,21 @@ div.cursor::after {
   height: 900% !important;
   background: linear-gradient(
     180deg,
-    rgba(255, 45, 149, 0.45),
-    rgba(255, 69, 0, 0.40),
-    rgba(255, 215, 0, 0.35),
-    rgba(124, 252, 0, 0.30),
-    rgba(0, 255, 255, 0.35),
-    rgba(30, 144, 255, 0.40),
-    rgba(147, 112, 219, 0.45),
-    rgba(255, 0, 255, 0.50),
-    rgba(255, 20, 147, 0.55)
+    #ff2d95,
+    #ff4500,
+    #ffd700,
+    #7cfc00,
+    #00ffff,
+    #1e90ff,
+    #9370db,
+    #ff00ff,
+    #ff1493
   ) !important;
   border-radius: inherit !important;
   animation: 8s linear infinite bp-animation !important;
   transform: translateY(0);
   will-change: transform !important;
+  filter: none !important;
+  opacity: 0.7 !important;
   z-index: 0 !important;
 }

--- a/themes/Bearded Theme/cursor-glow.css
+++ b/themes/Bearded Theme/cursor-glow.css
@@ -1,4 +1,4 @@
-/* Cursor glow layer used by the integrated runtime payload. */
+/* Cursor glow layer — static low-opacity gradient replaces blur filter for performance */
 div.cursor::after {
   content: '' !important;
   position: absolute !important;
@@ -8,21 +8,19 @@ div.cursor::after {
   height: 900% !important;
   background: linear-gradient(
     180deg,
-    #ff2d95,
-    #ff4500,
-    #ffd700,
-    #7cfc00,
-    #00ffff,
-    #1e90ff,
-    #9370db,
-    #ff00ff,
-    #ff1493
+    rgba(255, 45, 149, 0.45),
+    rgba(255, 69, 0, 0.40),
+    rgba(255, 215, 0, 0.35),
+    rgba(124, 252, 0, 0.30),
+    rgba(0, 255, 255, 0.35),
+    rgba(30, 144, 255, 0.40),
+    rgba(147, 112, 219, 0.45),
+    rgba(255, 0, 255, 0.50),
+    rgba(255, 20, 147, 0.55)
   ) !important;
   border-radius: inherit !important;
   animation: 8s linear infinite bp-animation !important;
   transform: translateY(0);
   will-change: transform !important;
-  filter: blur(4px) brightness(180%) !important;
-  opacity: 0.7 !important;
   z-index: 0 !important;
 }


### PR DESCRIPTION
## 改动内容

将光标拖尾改为默认不启用 GPU blur，同时保留运行时配置能力：

- 默认使用 `filter: none`，移除持续的 blur / brightness 合成开销
- 保留不透明渐变色，由运行时统一应用 `glowOpacity`
- 将 `glowBlur` 默认值改为 `0`
- 用户显式设置 `glowBlur > 0` 时仍可恢复模糊效果
- 增加回归测试，覆盖默认无 blur、透明度配置和显式 blur 三种路径

## 根因与修正

初版提交把 CSS 渐变改为半透明 `rgba`，但运行时的 `applyCursorSettings` 会用用户配置的渐变色替换整个 `linear-gradient(...)`。默认配置是十六进制颜色，因此半透明 alpha 会被覆盖，同时旧的 `opacity` 又被删除，最终生成不透明拖尾。

现在透明度由独立的 `opacity` 属性控制，不再依赖渐变色格式，因此默认颜色、自定义颜色和主题运行时替换都能保持一致。

## 验证

- `npm test -- --runInBand`：12 suites / 38 tests 通过
- `npm run compile`：通过
- 变更文件 ESLint：通过
- 变更文件 Prettier：通过

Closes #18