### PR TITLE
ci: refresh GitHub Actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- update `actions/checkout` and `actions/setup-node` from v4 to v7 so CI uses the current Node 24 action runtime
- run the repository toolchain on Node.js 22, matching the locally verified maintained runtime

## Why
The post-merge CI for #23 passed but emitted GitHub's Node.js 20 action-runtime deprecation warning. The current official releases are checkout v7.0.1 and setup-node v7.0.0.

## Validation
- `npx prettier --check .github/workflows/ci.yml`
- `git diff --check`